### PR TITLE
Notify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1376,6 +1376,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "tokio",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1472,6 +1473,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
 dependencies = [
  "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
  "pin-project-lite",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1376,6 +1376,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "tokio",
+ "tokio-stream",
  "tokio-util",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ tracing-subscriber = "0.3"
 
 [dev-dependencies]
 tokio = { version = "1.47.1", features = ["full"] }
+tokio-util = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,6 @@ tracing-subscriber = "0.3"
 
 
 [dev-dependencies]
-tokio = { version = "1.47.1", features = ["full"] }
+tokio = { version = "1.47.1", features = ["full", "test-util"] }
+tokio-stream = "0.1"
 tokio-util = "0.7"

--- a/Justfile
+++ b/Justfile
@@ -28,3 +28,7 @@ lint-ci:
 # Run tests
 test:
     cargo test --workspace
+
+# Generate by sqlc
+generate:
+    sqlc generate -f sqlc.json

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -12,7 +12,7 @@ async fn main() {
         .unwrap();
 
     let backend = BackEnd::new(pool.clone());
-    let worker = WorkerBuilder::new().build(job_handler);
+    let worker = WorkerBuilder::new().build(backend, job_handler);
 
     let client = Client::<u64>::new(pool.clone());
     let client_handle = async move {
@@ -33,7 +33,7 @@ async fn main() {
         }
     };
 
-    let worker_fut = worker.run(backend);
+    let worker_fut = worker.run();
     let mut tasks = tokio::task::JoinSet::new();
     tasks.spawn(client_handle);
     tasks.spawn(worker_fut);

--- a/examples/with_listener.rs
+++ b/examples/with_listener.rs
@@ -1,0 +1,64 @@
+use tasuki::{BackEnd, Client, InsertJob, JobData, JobResult, WorkerBuilder, WorkerContext};
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt()
+        .compact()
+        .with_max_level(tracing::Level::DEBUG)
+        .init();
+
+    let pool = sqlx::PgPool::connect("postgres://root:password@postgres:5432/app")
+        .await
+        .unwrap();
+
+    let backend = BackEnd::new(pool.clone());
+    let mut listener = backend.listener().await.unwrap();
+
+    let worker = WorkerBuilder::new()
+        .build(backend, job_handler)
+        .subscribe(&mut listener);
+
+    let client = Client::<u64>::new(pool.clone());
+    let client_handle = async move {
+        let mut interval = tokio::time::interval(std::time::Duration::from_millis(500));
+        let mut n = 0;
+        loop {
+            interval.tick().await;
+            let job = InsertJob::new(n);
+            match client.insert(job).await {
+                Ok(_) => {
+                    tracing::info!("Enqueue job {}", n);
+                    n += 1
+                }
+                Err(error) => {
+                    tracing::error!(error = %error, "Failed to enqueue job")
+                }
+            };
+        }
+    };
+
+    let worker_fut = AssertSend(worker.run());
+    let mut tasks = tokio::task::JoinSet::new();
+    tasks.spawn(client_handle);
+    tasks.spawn(worker_fut.0);
+
+    tasks.join_all().await;
+}
+
+async fn job_handler(
+    JobData(count): JobData<u64>,
+    WorkerContext(_): WorkerContext<()>,
+) -> JobResult {
+    let handle = tokio::spawn(async move {
+        tracing::info!("-start: job {}", count);
+        tokio::time::sleep(std::time::Duration::from_secs(count % 5 + 1)).await;
+
+        tracing::info!("--end: job {}", count)
+    });
+    match handle.await {
+        Ok(_) => JobResult::Cancel,
+        Err(_) => JobResult::Retry(None),
+    }
+}
+
+struct AssertSend<T: Send>(pub T);

--- a/examples/with_listener.rs
+++ b/examples/with_listener.rs
@@ -53,7 +53,11 @@ async fn main() {
     tasks.spawn(client_handle);
     tasks.spawn(worker_fut);
     // Stop the listener when the cancellation token is triggered (e.g., Ctrl+C)
-    tasks.spawn(listener.listen_until(token.clone().cancelled_owned()).map(|_| ()));
+    tasks.spawn(
+        listener
+            .listen_until(token.clone().cancelled_owned())
+            .map(|_| ()),
+    );
     tasks.spawn(async move {
         let _ = tokio::signal::ctrl_c().await;
         token.cancel();

--- a/examples/with_listener.rs
+++ b/examples/with_listener.rs
@@ -16,7 +16,8 @@ async fn main() {
 
     let worker = WorkerBuilder::new()
         .build(backend, job_handler)
-        .subscribe(&mut listener);
+        .subscribe(&mut listener)
+        .with_graceful_shutdown(async { tokio::signal::ctrl_c().await });
 
     let client = Client::<u64>::new(pool.clone());
     let client_handle = async move {

--- a/queries/queue.sql
+++ b/queries/queue.sql
@@ -69,3 +69,6 @@ INSERT INTO
   (max_attempts, job_data, queue_name)
 VALUES
   ($1, $2, $3);
+
+-- name: AddJobNotify :exec
+SELECT pg_notify(sqlc.arg(channel_name)::TEXT, json_build_obejct('q', sqlc.arg(queue_name)::TEXT)::TEXT);

--- a/queries/queue.sql
+++ b/queries/queue.sql
@@ -71,4 +71,7 @@ VALUES
   ($1, $2, $3);
 
 -- name: AddJobNotify :exec
-SELECT pg_notify(sqlc.arg(channel_name)::TEXT, json_build_obejct('q', sqlc.arg(queue_name)::TEXT)::TEXT);
+SELECT pg_notify(
+  sqlc.arg(channel_name)::TEXT,
+  json_build_object('q', sqlc.arg(queue_name)::TEXT)::TEXT
+);

--- a/sqlc.json
+++ b/sqlc.json
@@ -26,6 +26,11 @@
                                 "db_type": "uuid",
                                 "rs_type": "sqlx::types::Uuid",
                                 "copy_cheap": true
+                            },
+                            {
+                                "db_type": "void",
+                                "rs_type": "()",
+                                "copy_cheap": true
                             }
                         ]
                     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -170,6 +170,7 @@ where
     }
 
     /// Insert a job using an existing transaction or connection.
+    #[allow(clippy::manual_async_fn)]
     pub fn insert_tx<'a, 'c, A>(
         &self,
         data: InsertJob<T>,

--- a/src/client.rs
+++ b/src/client.rs
@@ -144,26 +144,61 @@ where
     T: Serialize + Send + Sync + 'static,
 {
     /// Insert a job into the queue using the client's connection pool.
-    pub fn insert(
-        &self,
-        data: InsertJob<T>,
-    ) -> impl Future<Output = Result<(), Error>> + Send + '_ {
-        self.insert_tx(data, &self.pool)
-    }
-
-    /// Insert a job using an existing transaction or connection.
-    pub async fn insert_tx<'a, 'c, A>(&self, data: InsertJob<T>, tx: A) -> Result<(), Error>
-    where
-        A: sqlx::Acquire<'c, Database = sqlx::Postgres> + Send + 'a,
-    {
+    pub async fn insert(&self, data: InsertJob<T>) -> Result<(), Error> {
         let value = serde_json::to_value(data.data)?;
+
+        let mut tx = self.pool.begin().await?;
+
         queries::InsertJobOne::builder()
             .job_data(&value)
             .max_attempts(data.max_attempts.into())
             .queue_name(&self.queue_name)
             .build()
-            .execute(tx)
+            .execute(&mut *tx)
             .await?;
+
+        queries::AddJobNotify::builder()
+            .channel_name(crate::worker::Listener::CHANNEL_NAME)
+            .queue_name(&self.queue_name)
+            .build()
+            .execute(&mut *tx)
+            .await?;
+
+        tx.commit().await?;
+
         Ok(())
+    }
+
+    /// Insert a job using an existing transaction or connection.
+    pub fn insert_tx<'a, 'c, A>(
+        &self,
+        data: InsertJob<T>,
+        tx: A,
+    ) -> impl Future<Output = Result<(), Error>>
+    where
+        A: sqlx::Acquire<'c, Database = sqlx::Postgres> + Send + 'a,
+    {
+        async move {
+            let value = serde_json::to_value(data.data)?;
+
+            let mut conn = tx.acquire().await?;
+
+            queries::InsertJobOne::builder()
+                .job_data(&value)
+                .max_attempts(data.max_attempts.into())
+                .queue_name(&self.queue_name)
+                .build()
+                .execute(&mut *conn)
+                .await?;
+
+            queries::AddJobNotify::builder()
+                .queue_name(&self.queue_name)
+                .channel_name(crate::worker::Listener::CHANNEL_NAME)
+                .build()
+                .execute(&mut *conn)
+                .await?;
+
+            Ok(())
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#[allow(unused)]
+#[allow(unused, clippy::manual_async_fn)]
 mod queries;
 
 const TASUKI_DEFAULT_QUEUE_NAME: &str = "tasuki_default";

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -951,8 +951,8 @@ mod tests {
         let counter_st = make_counter();
         let interval = tokio::time::interval(Duration::from_millis(200));
 
-        let throttled = counter_st
-            .throttle_with_tick(tokio_stream::wrappers::IntervalStream::new(interval), 0);
+        let throttled =
+            counter_st.throttle_with_tick(tokio_stream::wrappers::IntervalStream::new(interval), 0);
         tokio::pin!(throttled);
 
         // Verify across several windows that no item is yielded

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -92,6 +92,7 @@ trait ThrottleExt: Stream {
     }
 
     /// Same as [`throttle`] but with a custom ticker stream.
+    #[allow(unused)]
     fn throttle_with_tick<Tick>(self, ticker: Tick, max_count: usize) -> Throttle<Self, Tick>
     where
         Self: Sized,

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -205,11 +205,6 @@ pub struct Listener {
     publishers: std::collections::HashMap<String, Publisher>,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct ChannelData {
-    q: String,
-}
-
 impl Listener {
     pub(crate) const CHANNEL_NAME: &str = "tasuki_jobs";
     async fn new(pool: sqlx::PgPool) -> Result<Self, sqlx::Error> {
@@ -235,6 +230,11 @@ impl Listener {
         let mut publisers = self.publishers;
         let signal = signal.fuse();
         futures::pin_mut!(signal);
+
+        #[derive(Debug, Deserialize)]
+        struct ChannelData {
+            q: String,
+        }
 
         loop {
             futures::select! {
@@ -295,7 +295,7 @@ struct Publisher {
 
 pin_project! {
     #[derive(Debug)]
-    pub struct Subscribe {
+    struct Subscribe {
         #[pin]
         receiver: futures::channel::mpsc::Receiver<()>,
     }


### PR DESCRIPTION
**概要**
- LISTEN/NOTIFY ベースのジョブ通知を追加し、ポーリング待ちを削減。
- Worker に通知購読と 100ms/1件のスロットルを導入し、過剰フェッチとホットループを抑制。
- ジョブ投入時に `pg_notify` を発行してワーカーを即時起床。
**関連**
- Closes #11
