### PR TITLE
Backoff: default jitter and enum casts

### DIFF
--- a/examples/with_listener.rs
+++ b/examples/with_listener.rs
@@ -77,7 +77,7 @@ async fn job_handler(
         tracing::info!("--end: job {}", count)
     });
     match handle.await {
-        Ok(_) => JobResult::Cancel,
+        Ok(_) => JobResult::Complete,
         Err(_) => JobResult::Retry(None),
     }
 }

--- a/examples/with_listener.rs
+++ b/examples/with_listener.rs
@@ -18,6 +18,7 @@ async fn main() {
     let mut listener = backend.listener().await.unwrap();
 
     let worker = WorkerBuilder::new()
+        .tick(futures::stream::pending())
         .build(backend, job_handler)
         .subscribe(&mut listener)
         .with_graceful_shutdown(token.clone().cancelled_owned());

--- a/queries/queue.sql
+++ b/queries/queue.sql
@@ -55,7 +55,7 @@ WHERE
 UPDATE tasuki_job j
 SET 
   status = CASE 
-            WHEN j.attempts <= j.max_attempts THEN 'pending'::tasuki_job_status
+            WHEN j.attempts < j.max_attempts THEN 'pending'::tasuki_job_status
             ELSE 'failed'::tasuki_job_status
            END,
   scheduled_at = CASE

--- a/queries/queue.sql
+++ b/queries/queue.sql
@@ -2,7 +2,7 @@
 UPDATE 
   tasuki_job j
 SET
-  status = 'running',
+  status = 'running'::tasuki_job_status,
   attempts = j.attempts + 1,
   lease_expires_at = clock_timestamp() + sqlc.arg(lease_interval)::INTERVAL
 WHERE 
@@ -18,7 +18,7 @@ WHERE
         (status = 'running' AND lease_expires_at IS NOT NULL AND lease_expires_at <= NOW())
       )
       AND 
-      (scheduled_at <= NOW() AND attempts <= max_attempts AND queue_name = sqlc.arg(queue_name)::TEXT)
+      (scheduled_at <= NOW() AND attempts < max_attempts AND queue_name = sqlc.arg(queue_name)::TEXT)
     ORDER BY scheduled_at ASC
     FOR UPDATE SKIP LOCKED
     LIMIT sqlc.arg(batch_size)
@@ -37,7 +37,8 @@ WHERE
 UPDATE 
   tasuki_job j
 SET 
-  status = 'completed'
+  status = 'completed'::tasuki_job_status,
+  lease_expires_at = NULL
 WHERE
   id = $1;
 
@@ -45,7 +46,8 @@ WHERE
 UPDATE
   tasuki_job j
 SET
-  status = 'canceled'
+  status = 'canceled'::tasuki_job_status,
+  lease_expires_at = NULL
 WHERE
   id = $1;
 
@@ -53,13 +55,18 @@ WHERE
 UPDATE tasuki_job j
 SET 
   status = CASE 
-            WHEN j.attempts <= j.max_attempts THEN 'pending'
-            ELSE 'failed'
+            WHEN j.attempts <= j.max_attempts THEN 'pending'::tasuki_job_status
+            ELSE 'failed'::tasuki_job_status
            END,
   scheduled_at = CASE
-                  WHEN j.attempts <= j.max_attempts THEN clock_timestamp() + sqlc.arg(interval)::INTERVAL
+                  WHEN j.attempts < j.max_attempts 
+                    THEN clock_timestamp() + coalesce(
+                      sqlc.narg(interval),
+                      make_interval(secs := power(j.attempts, 4.0) * (0.9 + random() * 0.2))
+                      )::INTERVAL
                   ELSE scheduled_at
-                 END 
+                 END,
+  lease_expires_at = NULL
 WHERE 
   id = $1;
 


### PR DESCRIPTION
# バックオフ: 既定ジッター導入と再試行の安定化

**目的**
- 失敗時の過負荷回避と再試行の安定化。

**効果**
- スパイク負荷の平準化、DB/外部APIの保護。
- 既定バックオフ: `attempts^2` 秒に対して ±10% の一様ジッターを付与。
- キュー/ジョブ単位での上書き設定に対応（Rust 側は上書き時のみ遅延を明示）。

**変更点（概要）**
- 既定バックオフ式を SQL 側で一元計算し、Rust 側は上書き時のみ `interval` を指定。
- `RetryJob` のスケジュール再計算にジッター付き指数バックオフを適用（±10%）。
- `tasuki_job.status` への代入で enum へ明示キャストし、DB 型不一致エラーを解消。
- 再試行時に `lease_expires_at` をクリア。

**参考**
- バックオフ設計は River の実装方針（指数バックオフ + ジッター）を参考に`attempts ^ 4 +-10%` sec
  - Ref: https://riverqueue.com/docs/job-retries#client-retry-policy


